### PR TITLE
Remove dependency on specific `Libc` features

### DIFF
--- a/src/object_id.jl
+++ b/src/object_id.jl
@@ -53,23 +53,7 @@ function Base.show(io::IO, x::BSONObjectIdGenerator)
     print(io, "BSONObjectIdGenerator($(x.seq), $(x.rnd))")
 end
 
-if Sys.islinux()
-    struct LinuxTimespec
-        seconds::Clong
-        nanoseconds::Cuint
-    end
-    @inline function seconds_from_epoch_()
-        ts = Ref{LinuxTimespec}()
-        ccall(:clock_gettime, Cint, (Cint, Ref{LinuxTimespec}), 0, ts)
-        x = ts[]
-        x.seconds % UInt32
-    end
-else
-    @inline function seconds_from_epoch_()
-        tv = Libc.TimeVal()
-        tv.sec % UInt32
-    end
-end
+@inline seconds_from_epoch_() = trunc(UInt32, time())
 
 @inline id_from_parts_(t, r, s) = BSONObjectId((
     (t >> 24) % UInt8,


### PR DESCRIPTION
`trunc(UInt32, time())` does the same exact thing, since the extra nanosecond precision doesn't matter if we're only interested in seconds anyway.

I'm not familiar with BSON or it's spec, so I didn't want to change this to `UInt64`. May be advisable though, to prevent Y2106 style problems.

Ref https://github.com/JuliaLang/julia/pull/45023