### PR TITLE
bson_simple for simple namedtuples

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LightBSON"
 uuid = "a4a7f996-b3a6-4de6-b9db-2fa5f350df41"
 authors = ["Christian Rorvik <christian.rorvik@gmail.com>"]
-version = "0.2.14"
+version = "0.2.15"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/LightBSON.jl
+++ b/src/LightBSON.jl
@@ -65,6 +65,7 @@ bson_schema_version(::Type{T}) where T = nothing
 bson_schema_version_field(::Type{T}) where T = "_v"
 
 bson_simple(::Type{T}) where T = StructTypes.StructType(T) == StructTypes.NoStructType()
+bson_simple(::Type{<:NamedTuple}) = true
 
 include("object_id.jl")
 include("types.jl")

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -199,16 +199,6 @@ function Base.setindex!(writer::BSONWriter, fields::Tuple{Vararg{Pair{String, T}
     nothing
 end
 
-@generated function Base.setindex!(writer::BSONWriter, fields::T) where T <: NamedTuple
-    e = Expr(:block)
-    for fn in fieldnames(T)
-        fns = "$fn"
-        push!(e.args, :(writer[$fns] = fields.$fn))
-    end
-    push!(e.args, nothing)
-    e
-end
-
 @inline @generated function bson_write_simple(writer::BSONWriter, value::T) where T
     fieldcount(T) == 0 && return nothing
     totalsize = sum(wire_size_, fieldtypes(T)) + sum(sizeof, fieldnames(T)) + fieldcount(T) * 2


### PR DESCRIPTION
before:
```julia
julia> x = (;
           f1 = 1.25,
           f2 = Int64(123),
           f3 = now(UTC),
           f4 = true,
           f5 = Int32(456),
           f6 = d128"1.2",
       )
(f1 = 1.25, f2 = 123, f3 = DateTime("2022-10-04T21:45:23.841"), f4 = true, f5 = 456, f6 = 1.2)

julia> @btime begin
           buf = $(UInt8[])
           empty!(buf)
           writer = BSONWriter(buf)
           writer[] = $x
           close(writer)
       end
  74.212 ns (0 allocations: 0 bytes)
```
after
```julia
julia> @btime begin
           buf = $(UInt8[])
           empty!(buf)
           writer = BSONWriter(buf)
           writer[] = $x
           close(writer)
       end
  17.743 ns (0 allocations: 0 bytes)
```