### PR TITLE
reducible with BSONIndexUnsafe

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LightBSON"
 uuid = "a4a7f996-b3a6-4de6-b9db-2fa5f350df41"
 authors = ["Christian Rorvik <christian.rorvik@gmail.com>"]
-version = "0.2.15"
+version = "0.2.16"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"


### PR DESCRIPTION
Implements a more efficient "break" when foldl-ing. I just reduce on an isbit type, that I call "BSONIndexUnsafe", instead of a BSONReader.

I test:
```julia
julia> buf = UInt8[]
       writer = BSONWriter(buf)
       writer[] = (;a=[1,2,3])
       close(writer)

       @btime begin
           reader = BSONReader($buf)
           reader["a"]["2"][Int64]
       end

       @btime begin
           reader = BSONReader($buf)
           reader["a"][3][Int64]
       end
```

Before:
```julia
17.576 ns (0 allocations: 0 bytes)
108.146 ns (2 allocations: 64 bytes)
```
and after
```julia
 17.618 ns (0 allocations: 0 bytes)
 17.911 ns (0 allocations: 0 bytes)
```

A few remarks:
1. I'd like to remove the code duplication between:
- `function Transducers.__foldl__(rf, val, reader::BSONReader)`
- `function Transducers.__foldl__(rf, val, indices::BSONIndices)`
but I don't know how, but it should be doable, no? Obviously the first method would rely on the second one.
2. I'd like to remove the code duplication between:
- `Base.getindex(reader::BSONReader, target::Union{AbstractString, Symbol})`
- `function Transducers.__foldl__(rf, val, indices::BSONIndices)`
That seems more tricky because of the `name_len_and_match_` optimization.
3. You will notice that the field `el_type` of `BSONIndexUnsafe` is of type `Int`. It should be a `UInt8`. But if I do that, the benchmark above runs in 60ns. I don't understand why my "fix" as any kind of impact. Any idea?

Thanks,