### PR TITLE
partial parsing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LightBSON"
 uuid = "a4a7f996-b3a6-4de6-b9db-2fa5f350df41"
 authors = ["Christian Rorvik <christian.rorvik@gmail.com>"]
-version = "0.2.15"
+version = "0.2.16"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -402,6 +402,10 @@ function read_field_(reader::AbstractBSONReader, ::Type{Vector{T}}) where T
     copy!(dst, reader)
 end
 
+function read_field_(reader::T, ::Type{Union{AbstractBSONReader,AbstractBSONReader}}) where {T<:AbstractBSONReader}
+    reader
+end
+
 function Base.copy!(dst::AbstractArray{T}, reader::AbstractBSONReader) where T
     copy!(Map(x -> x.second[T]), dst, reader)
 end

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -402,7 +402,7 @@ function read_field_(reader::AbstractBSONReader, ::Type{Vector{T}}) where T
     copy!(dst, reader)
 end
 
-function read_field_(reader::T, ::Type{<:Union{T,AbstractBSONReader}}) where {T<:AbstractBSONReader}
+function read_field_(reader::T, ::Type{<:Union{T, AbstractBSONReader}}) where {T <: AbstractBSONReader}
     reader
 end
 

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -402,7 +402,7 @@ function read_field_(reader::AbstractBSONReader, ::Type{Vector{T}}) where T
     copy!(dst, reader)
 end
 
-function read_field_(reader::T, ::Type{Union{AbstractBSONReader,AbstractBSONReader}}) where {T<:AbstractBSONReader}
+function read_field_(reader::T, ::Type{<:Union{T,AbstractBSONReader}}) where {T<:AbstractBSONReader}
     reader
 end
 

--- a/test/reader_tests.jl
+++ b/test/reader_tests.jl
@@ -304,4 +304,13 @@ end
     @test sizeof(reader) == 19
 end
 
+@testset "getindex AbstractBSONReader" begin
+    buf = UInt8[]
+    writer = BSONWriter(buf)
+    writer["x"] = 123
+    close(writer)
+    reader = BSONReader(buf)
+    @test reader["x"][AbstractBSONReader] == reader["x"]
+end
+
 end

--- a/test/reader_tests.jl
+++ b/test/reader_tests.jl
@@ -311,6 +311,7 @@ end
     close(writer)
     reader = BSONReader(buf)
     @test reader["x"][AbstractBSONReader] == reader["x"]
+    @test reader["x"][typeof(reader)] == reader["x"]
 end
 
 end

--- a/test/struct_tests.jl
+++ b/test/struct_tests.jl
@@ -147,7 +147,25 @@ end
     writer[] = x
     close(writer)
     reader = BSONReader(buf)
-    reader[typeof(x)] == x
+    @test reader[typeof(x)] == x
+end
+
+struct Parametric{T}
+    type_encoding::Int
+    payload::T
+end
+
+@testset "AbstractBSONReader" begin
+    buf = UInt8[]
+    writer = BSONWriter(buf)
+    x = (; type_encoding = 1, payload = "test")
+    writer[] = x
+    close(writer)
+    reader = BSONReader(buf)
+    p = reader[Parametric{AbstractBSONReader}]
+    @test p.type_encoding == 1 
+    @test p.payload isa AbstractBSONReader
+    p.payload[String] == "test"
 end
 
 end

--- a/test/struct_tests.jl
+++ b/test/struct_tests.jl
@@ -166,6 +166,11 @@ end
     @test p.type_encoding == 1 
     @test p.payload isa AbstractBSONReader
     p.payload[String] == "test"
+
+    p = reader[Parametric{typeof(reader)}]
+    @test p.type_encoding == 1 
+    @test p.payload isa AbstractBSONReader
+    p.payload[String] == "test"
 end
 
 end


### PR DESCRIPTION
I'd like to be able to partially parse a document.
I would need to read a header before knowing the type I should use to parse the payload.
Partial parsing would allow me to avoid type instabillity.
```julia
struct MyStruct{T}
    field_encoding_the_type::Int
    payload::T
end

x = reader[MyStruct{AbstractBSONReader}]
if x.field_encoding_the_type == 0
    payload = x.payload[T] # using the corresponding type
    ...
elseif....
end
```
