### PR TITLE
UUID byte order

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LightBSON"
 uuid = "a4a7f996-b3a6-4de6-b9db-2fa5f350df41"
 authors = ["Christian Rorvik <christian.rorvik@gmail.com>"]
-version = "0.2.21"
+version = "0.2.22"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LightBSON"
 uuid = "a4a7f996-b3a6-4de6-b9db-2fa5f350df41"
 authors = ["Christian Rorvik <christian.rorvik@gmail.com>"]
-version = "0.2.22"
+version = "1.0.0"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -243,7 +243,7 @@ end
         )
         len = load_bits_(Int32, p)
         len != 16 && error("Unexpected UUID length $len")
-        return unsafe_load(Ptr{UUID}(p + 5))
+        return UUID(ntoh(unsafe_load(Ptr{UInt128}(p + 5))))
     end
 end
 
@@ -255,7 +255,7 @@ end
         subtype == BSON_SUBTYPE_UUID_OLD || throw(BSONConversionError(reader.type, subtype, BSONUUIDOld))
         len = load_bits_(Int32, p)
         len != 16 && error("Unexpected UUID length $len")
-        return BSONUUIDOld(unsafe_load(Ptr{UUID}(p + 5)))
+        return BSONUUIDOld(UUID(ntoh(unsafe_load(Ptr{UInt128}(p + 5)))))
     end
 end
 
@@ -439,9 +439,9 @@ function read_field_(reader::AbstractBSONReader, ::Type{Any})
         x = reader[BSONBinary]
         data = x.data
         if x.subtype == BSON_SUBTYPE_UUID && length(data) == 16
-            GC.@preserve data unsafe_load(Ptr{UUID}(pointer(data)))
+            GC.@preserve data UUID(ntoh(unsafe_load(Ptr{UInt128}(pointer(data)))))
         elseif x.subtype == BSON_SUBTYPE_UUID_OLD && length(data) == 16
-            GC.@preserve data BSONUUIDOld(unsafe_load(Ptr{UUID}(pointer(data))))
+            GC.@preserve data BSONUUIDOld(UUID(ntoh(unsafe_load(Ptr{UInt128}(pointer(data))))))
         else
             x
         end

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -71,13 +71,13 @@ end
 @inline function wire_store_(p::Ptr{UInt8}, x::UUID)
     unsafe_store!(Ptr{Int32}(p), Int32(16))
     unsafe_store!(p + 4, BSON_SUBTYPE_UUID)
-    unsafe_store!(Ptr{UUID}(p + 5), x)
+    unsafe_store!(Ptr{UInt128}(p + 5), hton(UInt128(x.value)))
 end
 
 @inline function wire_store_(p::Ptr{UInt8}, x::BSONUUIDOld)
     unsafe_store!(Ptr{Int32}(p), Int32(16))
     unsafe_store!(p + 4, BSON_SUBTYPE_UUID_OLD)
-    unsafe_store!(Ptr{UUID}(p + 5), x.value)
+    unsafe_store!(Ptr{UInt128}(p + 5), hton(UInt128(x.value)))
 end
 
 @inline function wire_store_(p::Ptr{UInt8}, x::Union{BSONBinary, UnsafeBSONBinary})

--- a/test/reader_tests.jl
+++ b/test/reader_tests.jl
@@ -153,7 +153,7 @@ end
     io = IOBuffer()
     write(io, htol(Int32(16)))
     write(io, BSON_SUBTYPE_UUID)
-    unsafe_write(io, Ref(x), 16)
+    unsafe_write(io, Ref(hton(UInt128(x))), 16)
     reader = BSONReader(single_field_doc_(BSON_TYPE_BINARY, take!(io)))
     @test reader["x"][UUID] == x
     @test reader["x"][Any] == x


### PR DESCRIPTION
Byte ordering in MongoDB has a messy history. The old binary subtype 0x03 had implementation defined byte ordering. Technically drivers are meant to expose configuration to deal with this. Subtype 0x04 implements byte order in accordance with RFC 4122, from most to least significant byte, e.g., canonical network byte order.

See https://github.com/mongodb/specifications/blob/master/source/bson-binary-uuid/uuid.md for details.

Updating major version since this is a potentially data breaking change.