### PR TITLE
Write from reader

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LightBSON"
 uuid = "a4a7f996-b3a6-4de6-b9db-2fa5f350df41"
 authors = ["Christian Rorvik <christian.rorvik@gmail.com>"]
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -185,6 +185,13 @@ end
     end
 end
 
+@inline function Base.setindex!(writer::BSONWriter, reader::BSONReader, name::Union{String, Symbol})
+    len = sizeof(reader)
+    offset = write_header_(writer.dst, reader.type, name, len)
+    GC.@preserve reader writer unsafe_copyto!(pointer(writer.dst) + offset, pointer(reader), len)
+    nothing
+end
+
 function Base.setindex!(writer::BSONWriter, fields::AbstractDict{<:Union{String, Symbol}})
     for (key, value) in fields
         writer[key] = value

--- a/test/writer_tests.jl
+++ b/test/writer_tests.jl
@@ -158,4 +158,21 @@ end
     @test BSONReader(buf, StrictBSONValidator())["x"][EmptyStruct] == EmptyStruct()
 end
 
+@testset "from reader" begin
+    doc1 = bson_write(UInt8[], (; x = 1, y = "foo"))
+    doc2 = bson_write(UInt8[], (; z = false))
+    buf = empty!(fill(0xff, 1000))
+    writer = BSONWriter(buf)
+    writer["a"] = BSONReader(doc1)
+    writer["b"] = BSONReader(doc2)
+    writer["c"] = [BSONReader(doc1), BSONReader(doc2)]
+    close(writer)
+    @test BSONReader(buf, StrictBSONValidator())["a"][Any] == LittleDict("x" => 1, "y" => "foo")
+    @test BSONReader(buf, StrictBSONValidator())["b"][Any] == LittleDict("z" => false)
+    @test BSONReader(buf, StrictBSONValidator())["c"][Any] == [
+        LittleDict("x" => 1, "y" => "foo"),
+        LittleDict("z" => false)
+    ]
+end
+
 end


### PR DESCRIPTION
To enable fast embedding of already serialized documents